### PR TITLE
small fix to resolve error involving middleware + update to requireme…

### DIFF
--- a/audiopedia/audiopedia/settings.py
+++ b/audiopedia/audiopedia/settings.py
@@ -51,8 +51,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'corsheaders.middleware.CorsMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'graphql_jwt.middleware.JSONWebTokenMiddleware',
+    # 'graphql_jwt.middleware.JSONWebTokenMiddleware',
 ]
 
 ROOT_URLCONF = 'audiopedia.urls'
@@ -109,6 +108,9 @@ AUTH_PASSWORD_VALIDATORS = [
 
 GRAPHENE = {
     'SCHEMA': 'audiopedia.schema.schema',
+    'MIDDLEWARE': [
+        'graphql_jwt.middleware.JSONWebTokenMiddleware',
+    ],
 }
 AUTHENTICATION_BACKENDS = [
     'graphql_jwt.backends.JSONWebTokenBackend',

--- a/audiopedia/requirements.txt
+++ b/audiopedia/requirements.txt
@@ -4,15 +4,16 @@ certifi==2020.6.20
 Django==3.1.2
 django-cors-headers==3.5.0
 django-filter==2.4.0
+django-graphql-jwt==0.3.1
 graphene==2.1.8
 graphene-django==2.13.0
 graphql-core==2.3.2
 graphql-relay==2.0.1
 promise==2.3
+PyJWT==1.7.1
 pytz==2020.1
 Rx==1.6.1
 singledispatch==3.4.0.3
 six==1.15.0
 sqlparse==0.3.1
 Unidecode==1.1.1
-django-graphql-jwt==1.6.1


### PR DESCRIPTION
In the settings.py file, I had an error when trying to do `python manage.py runserver`, so after taking a look at the django-graphql-jwt docs, I noticed that the middleware should be added within the GRAPHENE dict. 

Also updated the requirements.txt file with the correct version for django-graphql-jwt.